### PR TITLE
fix zero size panic in difference calc

### DIFF
--- a/setutil.go
+++ b/setutil.go
@@ -14,6 +14,7 @@ func equal(a, b []uint16) bool {
 
 func difference(set1 []uint16, set2 []uint16, buffer []uint16) int {
 	if 0 == len(set2) {
+		buffer = buffer[:len(set1)]
 		for k := 0; k < len(set1); k++ {
 			buffer[k] = set1[k]
 		}


### PR DESCRIPTION
when set2 size was 0 it resulted in panic: `runtime error: index out of range [0] with length 0`