### PR TITLE
Adding computation of cardinality to ContainerFromBitmapBytes

### DIFF
--- a/roaringarray.go
+++ b/roaringarray.go
@@ -113,7 +113,9 @@ func ContainerFromBitmapBytes(bytes []byte) Container {
 	if len(bytes) != 8192 {
 		panic("slice must be 8192 bytes")
 	}
-	return &bitmapContainer{bitmap: byteSliceAsUint64Slice(bytes)}
+	container := &bitmapContainer{bitmap: byteSliceAsUint64Slice(bytes)}
+	container.computeCardinality()
+	return container
 }
 
 func ContainerFromArrayBytes(bytes []byte) Container {


### PR DESCRIPTION
Cardinality is precalculated for bitmap containers. Need to do this
when creating the container.